### PR TITLE
Babel now runs dynamically, no need to compile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,8 +17,8 @@ var paths = {
 
 
 // The default task (called when we run `gulp` from cli)
-gulp.task('default', ['watch', 'js']);
-
+//gulp.task('default', ['watch', 'js']);
+gulp.task('default', function() {console.log("You don't need gulp anymore, silly!");})
 // Rerun tasks whenever a file changes.
 gulp.task('watch', function() {
   gulp.watch(paths.js, ['js']);

--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
     <div id="content"></div>
 
     <script src="requirements.js"></script>
-    <!--<script src="src/js/pages/index.js"></script>-->
     <script type="text/javascript">require("./src/js/pages/index");</script>
 
   </body>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
     <div id="content"></div>
 
     <script src="requirements.js"></script>
-    <script src="dist/js/app.js"></script>
+    <!--<script src="src/js/pages/index.js"></script>-->
+    <script type="text/javascript">require("./src/js/pages/index");</script>
 
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ let mainWindow
 
 function createWindow () {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600,icon: 'https://s-media-cache-ak0.pinimg.com/236x/89/c1/30/89c13062417a719f4899b62bf340603e.jpg'});
+  mainWindow = new BrowserWindow({width: 800, height: 600, icon: 'images/TC_Icon.png'});
 
   // and load the index.html of the app.
   mainWindow.loadURL(`file://${__dirname}/index.html`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "translation-core",
-  "version": "0.1.0",
+  "name": "Translation Core",
+  "version": "0.2.0",
   "description": "A bridge between TS and TM",
   "main": "main.js",
   "scripts": {
@@ -33,16 +33,17 @@
     "gulp-shell": "^0.5.2",
     "reactify": "^1.1.1",
     "vinyl-source-stream": "^1.1.0",
-        "watchify": "^3.7.0"
+    "watchify": "^3.7.0"
   },
   "dependencies": {
     "adm-zip": "^0.4.7",
+    "babel-register": "^6.9.0",
     "event-emitter": "^0.3.4",
     "flux": "^2.1.1",
     "fs": "0.0.2",
     "fs-extra": "^0.30.0",
-    "http": "0.0.0",
     "gogs-client": "^0.5.1",
+    "http": "0.0.0",
     "marked": "^0.3.5",
     "react": "^15.2.1",
     "react-bootstrap": "^0.29.5",
@@ -52,6 +53,5 @@
     "request": "^2.72.0",
     "sql.js": "^0.3.2",
     "url": "^0.11.0"
-  
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,17 +23,13 @@
   "homepage": "https://github.com/WycliffeAssociates/8woc#readme",
   "devDependencies": {
     "babel-preset-react": "^6.11.0",
-    "babelify": "^7.3.0",
-    "browserify": "^13.0.1",
     "del": "^2.2.1",
     "eslint": "^2.13.1",
     "eslint-config-google": "^0.6.0",
     "gulp": "^3.9.1",
     "gulp-debug": "^2.1.2",
     "gulp-shell": "^0.5.2",
-    "reactify": "^1.1.1",
-    "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.7.0"
+    "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
     "adm-zip": "^0.4.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Translation Core",
+  "name": "translation-core",
   "version": "0.2.0",
   "description": "A bridge between TS and TM",
   "main": "main.js",

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -1,0 +1,47 @@
+const ReactDOM = require('react-dom');
+const React = require('react');
+const NavBarComponent = require('../components/core/NavBarComponent');
+const PhraseModuleView = require('../components/modules/phrase_check_module/CheckModuleView');
+const LexicalModuleView = require('../components/modules/lexical_check_module/CheckModuleView');
+
+const NavMenu = require('../components/core/NavigationMenu');
+const remote = window.electron.remote;
+const {Menu} = remote;
+const TPane = require('../components/core/TPane');
+
+
+const LoginModal = require('../components/core/LoginModal');
+const UploadModal = require('../components/core/UploadModal');
+const MenuBar = require('../components/core/MenuBar');
+const SettingsModal = require('../components/core/SettingsModal');
+const RootStyles = require('./RootStyle');
+const Grid = require('react-bootstrap/lib/Grid.js');
+const Row = require('react-bootstrap/lib/Row.js');
+const Col = require('react-bootstrap/lib/Col.js');
+const NextButton = require('../components/core/NextButton');
+const SwitchCheckModuleDropdown = require('../components/core/SwitchCheckModuleDropdown');
+
+module.exports = (
+  <div>
+    <NavBarComponent />
+    <LoginModal />
+    <UploadModal />
+    <Grid fluid>
+      <Row>
+        <Col style={RootStyles.SideMenu} md={2} sm={2}>
+          <SettingsModal />
+          <NavMenu />
+        </Col>
+      </Row>
+      <Row>
+        <Col style={RootStyles.CheckSection} xs={10} md={10} lg={10} xsOffset={2} mdOffset={2}>
+          <TPane />
+
+          <SwitchCheckModuleDropdown />
+          {/* <PhraseModuleView /> OR <LexicalModuleView /> */}
+          <NextButton style={{float: 'right'}} />
+        </Col>
+      </Row>
+    </Grid>
+  </div>
+);

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -1,18 +1,15 @@
-const ReactDOM = require('react-dom');
-const React = require('react');
+  const React = require('react');
 const NavBarComponent = require('../components/core/NavBarComponent');
 const PhraseModuleView = require('../components/modules/phrase_check_module/CheckModuleView');
 const LexicalModuleView = require('../components/modules/lexical_check_module/CheckModuleView');
 
 const NavMenu = require('../components/core/NavigationMenu');
-const remote = window.electron.remote;
-const {Menu} = remote;
 const TPane = require('../components/core/TPane');
 
 
 const LoginModal = require('../components/core/LoginModal');
 const UploadModal = require('../components/core/UploadModal');
-const MenuBar = require('../components/core/MenuBar');
+
 const SettingsModal = require('../components/core/SettingsModal');
 const RootStyles = require('./RootStyle');
 const Grid = require('react-bootstrap/lib/Grid.js');

--- a/src/js/pages/index.js
+++ b/src/js/pages/index.js
@@ -1,4 +1,8 @@
 (function() {
+  // added by EW, necessary for dynamic JSX compilation
+  require("babel-register")({
+    extensions: [".js", ".jsx"]
+  });
   const ReactDOM = require('react-dom');
   const React = require('react');
   const PhraseModuleView = require('../components/modules/phrase_check_module/CheckModuleView');
@@ -25,34 +29,11 @@
     init: function() {
       var menu = Menu.buildFromTemplate(MenuBar.template);
       Menu.setApplicationMenu(menu);
-      var Application = (
-        <div>
-          <NavBarComponent />
-          <LoginModal />
-          <UploadModal />
-          <Grid fluid>
-            <Row>
-              <Col style={RootStyles.SideMenu} md={2} sm={2}>
-                <SettingsModal />
-                <NavMenu />
-              </Col>
-            </Row>
-            <Row>
-              <Col style={RootStyles.CheckSection} xs={10} md={10} lg={10} xsOffset={2} mdOffset={2}>
-                <TPane />
-
-                <SwitchCheckModuleDropdown />
-                {/* <PhraseModuleView /> OR <LexicalModuleView /> */}
-                <NextButton style={{float: 'right'}} />
-              </Col>
-            </Row>
-          </Grid>
-        </div>
-      );
+      var Application = require("./app");
       ReactDOM.render(Application, document.getElementById('content'));
     }
   };
-
+  App.init();
   window.App = App;
 })();
-document.addEventListener('DOMContentLoaded', App.init);
+//document.addEventListener('DOMContentLoaded', App.init);

--- a/src/js/pages/index.js
+++ b/src/js/pages/index.js
@@ -5,25 +5,9 @@
   });
   const ReactDOM = require('react-dom');
   const React = require('react');
-  const PhraseModuleView = require('../components/modules/phrase_check_module/CheckModuleView');
-  const LexicalModuleView = require('../components/modules/lexical_check_module/CheckModuleView');
-
-  const NavMenu = require('../components/core/NavigationMenu');
   const remote = window.electron.remote;
   const {Menu} = remote;
-  const TPane = require('../components/core/TPane');
-
-  const NavBarComponent = require('../components/core/NavBarComponent');
-  const LoginModal = require('../components/core/LoginModal');
-  const UploadModal = require('../components/core/UploadModal');
   const MenuBar = require('../components/core/MenuBar');
-  const SettingsModal = require('../components/core/SettingsModal');
-  const RootStyles = require('./RootStyle');
-  const Grid = require('react-bootstrap/lib/Grid.js');
-  const Row = require('react-bootstrap/lib/Row.js');
-  const Col = require('react-bootstrap/lib/Col.js');
-  const NextButton = require('../components/core/NextButton');
-  const SwitchCheckModuleDropdown = require('../components/core/SwitchCheckModuleDropdown');
 
   var App = {
     init: function() {
@@ -33,7 +17,6 @@
       ReactDOM.render(Application, document.getElementById('content'));
     }
   };
-  App.init();
   window.App = App;
 })();
-//document.addEventListener('DOMContentLoaded', App.init);
+document.addEventListener('DOMContentLoaded', App.init);


### PR DESCRIPTION
Main update was to include babel-register (will need to npm install this after pulling). This makes JSX compilation dynamic without the need to gulp at all. The gulp file was modified to do nothing but output when run on the default task. Several modules were removed from the package.json as they were no longer needed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/8woc/108)

<!-- Reviewable:end -->
