### PR TITLE
Phrase Checker's navigation menu shows pretty group headers

### DIFF
--- a/modules/phrase_check_module/FetchData.js
+++ b/modules/phrase_check_module/FetchData.js
@@ -77,7 +77,8 @@ var parseObject = function(object){
   return phraseObject;
 }
 
-// Returns an object where the keys are TA section filenames and the values are titles
+// Saves an object where the keys are TA section filenames and the values are titles.
+// This will be called when TA is loaded
 function getSectionFileNamesToTitles(params) {
   var sections = params.sections;
 	var sectionFileNamesToTitles = {};
@@ -89,6 +90,8 @@ function getSectionFileNamesToTitles(params) {
 	translationAcademySectionTitles = sectionFileNamesToTitles;
 }
 
+// Waits until the translationAcademySectionTitles object exists,
+// then changes the group headers to TA section titles
 function checkIfTranslationAcademyIsLoaded() {
   if(translationAcademySectionTitles) {
     changeGroupHeaders(phraseData, translationAcademySectionTitles);
@@ -99,6 +102,7 @@ function checkIfTranslationAcademyIsLoaded() {
   }
 }
 
+// Changes the group headers from filenames to TA section titles
 function changeGroupHeaders(phraseObject, groupNamesToTitles) {
   for(var group of phraseObject.groups) {
     var filename = group['group'] + '.md';
@@ -109,13 +113,12 @@ function changeGroupHeaders(phraseObject, groupNamesToTitles) {
   }
 }
 
+// Saves phrase data into the CheckStore
 function saveData(phraseObject) {
-  //put the data in the CheckStore
   api.putDataInCheckStore('PhraseCheck', 'groups', phraseObject['groups']);
   api.putDataInCheckStore('PhraseCheck', 'currentCheckIndex', 0);
   api.putDataInCheckStore('PhraseCheck', 'currentGroupIndex', 0);
   // TODO: eventually, this event will be called when the check type is selected, not in fetchData
-  api.emitEvent('phraseDataLoaded');
   onCompleteFunction(null);
 }
 

--- a/modules/phrase_check_module/View.js
+++ b/modules/phrase_check_module/View.js
@@ -17,7 +17,6 @@ class PhraseChecker extends React.Component{
   }
 
   componentWillMount() {
-    api.registerEventListener('phraseDataLoaded', this.updateRender.bind(this));
     this.TPane = api.getModule('TPane');
     this.TADisplay = api.getModule('TADisplay');
     this.ProposedChanges = api.getModule('ProposedChanges');

--- a/modules/translation_academy/FetchData.js
+++ b/modules/translation_academy/FetchData.js
@@ -1,10 +1,19 @@
+/*
+ * Events emitted:
+ * 	translationAcademyLoaded:
+ * 		params:
+ * 			sections: an object where keys are section filenames, and values are section text
+ * 		listeners:
+ * 			PhraseChecker FetchData: waits for translation academy to load so it can use
+ * 			the section titles as its group headers
+ */
 
 const api = window.ModuleApi;
 
 const TranslationAcademyScraper = require('./TranslationAcademyScraper');
 
 function fetchData(params, progress, callback) {
-	TranslationAcademyScraper.getTranslationAcademySectionList(null, function(sectionList) {
+	TranslationAcademyScraper.getFullTranslationAcademySectionList(function(sectionList) {
 		fetchAllSections(sectionList, progress, callback)
 	});
 }
@@ -24,21 +33,11 @@ function fetchAllSections(sectionList, progress, callback) {
 		var sectionList = TranslationAcademyScraper.sectionList;
 		// TODO: eventually should save sections to json file
 		api.putDataInCheckStore('TranslationAcademy', 'sectionList', sectionList);
-		callback(getSectionFileNamesToTitles(sectionList), null);
+  	api.emitEvent("translationAcademyLoaded", {'sections': sectionList});
+		callback();
 	}, reason => {
-		callback(null, 'Translation Academy failed to fetch.');
+		callback('Translation Academy failed to fetch section text.');
 	});
-}
-
-// Returns an object where the keys are section filenames and the values are titles
-function getSectionFileNamesToTitles(sectionList) {
-	var sectionFileNamesToTitles = {};
-	for(var sectionFileName in sectionList) {
-		var titleKeyAndValue = sectionList[sectionFileName]['file'].match(/title: .*/)[0];
-		var title = titleKeyAndValue.substr(titleKeyAndValue.indexOf(':') + 1);
-		sectionFileNamesToTitles[sectionFileName] = title;
-	}
-	return sectionFileNamesToTitles;
 }
 
 module.exports = fetchData;

--- a/modules/translation_academy/TranslationAcademyScraper.js
+++ b/modules/translation_academy/TranslationAcademyScraper.js
@@ -1,27 +1,41 @@
 
 
 const BASE_URL = "https://git.door43.org/";
-const TA_URL = "Door43/en-ta-translate-vol1/src/master/content";
+const TA_URLS = [
+  "Door43/en-ta-translate-vol1/src/master/content",
+  "Door43/en-ta-translate-vol2/src/master/content"
+];
 // creates TranslationAcademyScraper class
 class TranslationAcademyScraper {
   constructor() {
     this.sectionList = {};
-    this.link = null;
   }
-// gets the list of sections from tranlation academy by its url then fires the call back when done
-  getTranslationAcademySectionList(url, callback) {
+  
+  getFullTranslationAcademySectionList(callback) {
+    var promises = [];
+    for(let taUrl of TA_URLS) {
+		  var promise = new Promise((resolve, reject) => {
+        this.getTranslationAcademySectionListForUrl(taUrl, resolve);
+      });
+      promises.push(promise);
+    }
+	  Promise.all(promises).then(value => {
+      callback(this.sectionList);
+    }, reason => {
+      console.log('Translation Academy failed to load section list.');
+    });
+  }
+  
+  // Gets the list of sections from translation academy by its url then fires the call back when done
+  getTranslationAcademySectionListForUrl(taUrl, callback) {
     var _this = this;
     var oReq = new XMLHttpRequest();
     oReq.onload = function() {
-// this defines a new function that will be called later
       var links = getItemsBehindLink(this.response);
       _this.sectionList = mergeObjects(_this.sectionList, links);
-      _this.link = url;
       callback(_this.sectionList);
     };
-// created a new httprequest
-
-    oReq.open("Get", url || BASE_URL + TA_URL, true);
+    oReq.open("Get", BASE_URL + taUrl, true);
     oReq.send();
   }
 

--- a/src/js/components/core/NavigationMenu.js
+++ b/src/js/components/core/NavigationMenu.js
@@ -16,11 +16,11 @@ class NavigationMenu extends React.Component {
   }
 
   componentWillMount() {
-    api.registerEventListener('changeCheckType', this.updateCheckObject.bind(this));
+    api.registerEventListener('changeCheckType', this.updateCheckObject);
   }
 
   componentWillUnmount() {
-    api.removeEventListener('changeCheckType', this.updateCheckObject.bind(this));
+    api.removeEventListener('changeCheckType', this.updateCheckObject);
   }
   
   updateCheckObject(params) {

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -73,7 +73,6 @@ lexicalFetcher(params, function() {}, function(error) {
   if (error) console.error(error); 
   api.emitEvent('updateGatewayLanguage');
   api.emitEvent('lexicalDataLoaded'); 
-  api.emitEvent('phraseDataLoaded'); 
 api.emitEvent('changeCheckType', {currentCheckNamespace: "LexicalCheck"});} 
 ); 
 const ModuleWrapper = require('../components/modules/ModuleWrapper');

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -39,16 +39,14 @@ api.saveModule('TPane', TPane);
 const phraseFetcher = require(window.__base + "/modules/phrase_check_module/FetchData.js");
 phraseFetcher(params, function() {}, function() {
   api.emitEvent('updateGatewayLanguage');
-  api.emitEvent('changeCheckType', {currentCheckData: api.getDataFromCheckStore("PhraseCheck")});
 });
 const Phrase = require(window.__base + "modules/phrase_check_module/View.js");
 
 const tAFetcher = require(window.__base + "modules/translation_academy/FetchData.js");
-tAFetcher(params, function() {}, function(sectionFileNamesToTitles, err) {
+tAFetcher(params, function() {}, function(err) {
   if (err) {
     console.error(err);
   }
-  api.emitEvent("changeGroupHeaders", sectionFileNamesToTitles);
   api.emitEvent("changeTranslationAcademySection", {sectionName: "choose_team.md"})
 });
 


### PR DESCRIPTION
Phrase checker FetchData waits for TA FetchData to finish, then it switches its group names for the TA section titles. For example, "figs_metaphor" to "Metaphor".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/8woc/145)

<!-- Reviewable:end -->
