### PR TITLE
Fixed path bug for reports on OSX

### DIFF
--- a/src/js/components/core/reports/ReportGenerator.js
+++ b/src/js/components/core/reports/ReportGenerator.js
@@ -103,7 +103,7 @@ module.exports = function(callback = (err) => {}) {
     reportHTML.innerHTML = data;
     // render the ReportView output to new file report.html
     ReactDOM.render(<Report />, reportHTML.getElementsByTagName('div')[0]);
-    fs.writeFile(`${__dirname}\\report.html`, reportHTML.innerHTML, 'utf-8', (err) => {
+    fs.writeFile(`${__dirname}/report.html`, reportHTML.innerHTML, 'utf-8', (err) => {
       if (err) {
         console.log("Error writing rendered report to disk");
         callback(err);
@@ -111,7 +111,7 @@ module.exports = function(callback = (err) => {}) {
       }
       // display the file in a new browser window
       window.reportView = new BrowserWindow({autoHideMenuBar: true, width: 600, height: 600, title: "Check Report", icon: 'images/TC_Icon.png'});
-      window.reportView.loadURL(`file://${__dirname}\\report.html`);
+      window.reportView.loadURL(`file://${__dirname}/report.html`);
       window.reportView.on('closed', () => {
         window.reportView = undefined;
       });


### PR DESCRIPTION
On Macs, when creating a report.html file, the slashes were being misinterpreted. I switched the slash direction from \ to / and this seems to work cross platform

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/8woc/223)

<!-- Reviewable:end -->
