### PR TITLE
Fix an issue with Mac headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,7 +203,6 @@ $RECYCLE.BIN/
 *.sqlite*
 userdata.sqlite
 .config
-AuthToken.js
 Authentication.js
 #############
 ## Python

--- a/src/js/components/core/AuthToken.js
+++ b/src/js/components/core/AuthToken.js
@@ -2,6 +2,6 @@ const FileModule = require('./FileModule');
 
 FileModule.readFile('.config', function(data){
 	module.exports = {
-		token: data
+		token: data.trim()
 	}
 });

--- a/src/js/components/core/login/Registration.js
+++ b/src/js/components/core/login/Registration.js
@@ -74,6 +74,8 @@ const Registration = React.createClass({
       .then(function(data) {
         CoreActions.login(data);
         CoreActions.updateLoginModal(false);
+        CoreActions.updateOnlineStatus(true);
+        CoreActions.updateProfileVisibility(true);
       })
       .catch(function(reason) {
         console.log(reason);


### PR DESCRIPTION
This fixes issue #276 and #252

The issue was caused by some text editors automatically adding a
blank line after the auth token in the .config file. This has been
fixed by trimming the return line when fetching the token.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/8woc/283)

<!-- Reviewable:end -->
